### PR TITLE
Add HuGaDB dataset reader to DAGHAR

### DIFF
--- a/dataset_generator.py
+++ b/dataset_generator.py
@@ -30,6 +30,7 @@ from readers import (
     read_realworld,
     sanity_function,
     real_world_organize,
+    read_hugadb
 )
 
 """This module is used to generate the datasets. The datasets are generated in the following steps:    
@@ -72,6 +73,7 @@ dataset_paths: Dict[str, str] = {
     "WISDM": "WISDM/wisdm-dataset/raw/phone",
     "UCI": "UCI/RawData",
     "RealWorld": "RealWorld/realworld2016_dataset",
+    "HuGaDB": "HuGaDB"
 }
 
 # Dictionary with datasets and their respesctive reader functions
@@ -81,6 +83,7 @@ dataset_readers: Dict[str, callable] = {
     "WISDM": read_wisdm,
     "UCI": read_uci,
     "RealWorld": read_realworld,
+    "HuGaDB": read_hugadb
 }
 
 # Preprocess the datasets
@@ -351,6 +354,7 @@ if __name__ == "__main__":
         "WISDM",
         "UCI",
         "RealWorld",
+        "HuGaDB",
     ]
     
     parser = argparse.ArgumentParser(description="Dataset Generator")


### PR DESCRIPTION
This PR extends the DAGHAR benchmark to also include the [HuGaDB](https://github.com/romanchereshnev/HuGaDB) dataset.

Activity mapping and pipelines are defined following the code standard set by the benchmark. Note that HuGaDB has a "sitting in car" activity, which was mapped to sitting. This behavior may be changed.

This PR does not explicitly set download options for the database, since it was not a part of the original paper. On this version, it is expected that the user places the .zip file inside of `data/original` and unzips it.
 